### PR TITLE
Fixed the Homepage carousel on Safari

### DIFF
--- a/assets/css/app/home-ai.scss
+++ b/assets/css/app/home-ai.scss
@@ -121,7 +121,7 @@ div#wrapper.main {
 
 @media(max-width: $screen-sm-min) {
 	#ai-board-carousel figure{
-		width: 100vw;
+		width: 100%;
 	}
 	#ai-board-carousel figure img{
 		padding: 0 10px;

--- a/assets/css/app/home-carousel.scss
+++ b/assets/css/app/home-carousel.scss
@@ -9,7 +9,7 @@ $theta: 2 * 3.141592653589793 / $n;
 $apothem: 482.842712474619px;
 
 
-.carousel {
+.carousel#ai-board-carousel {
 	padding: 20px;
 	perspective: $viewer-distance;	
 	display: flex;
@@ -35,7 +35,7 @@ $apothem: 482.842712474619px;
 			-webkit-user-select: none;
 			user-select: none;
   
-			width: 100%;
+			width: 800px;
 			box-sizing: border-box;
 			padding: 0 $item-separation / 2;
 						
@@ -74,4 +74,30 @@ $apothem: 482.842712474619px;
 		}
 	}
 	
+}
+//Safari Carousel
+#safari-carousel{
+    display: none;
+}
+.carousel-inner img {
+    object-fit: contain;
+}
+.carousel-inner .item{
+    background-color:transparent;
+}
+.carousel-caption {
+	background-color: black;
+	opacity: .8;
+}
+.navbar-header {
+	z-index: 9999;
+}
+#safari-carousel .btn.view-more-info {
+	display: block;
+	background-color: black;
+	border: 1px solid white;
+	width: 100px;
+	margin: 10px auto;
+	padding: 5px;
+	opacity: .7;
 }

--- a/assets/js/app/home.js
+++ b/assets/js/app/home.js
@@ -8,4 +8,8 @@ $(document).ready(function(){
     $("#ultra96").click(function(){
         location.href='/products/ultra96/';
     });
+    if (navigator.userAgent.match(/AppleWebKit/) && ! navigator.userAgent.match(/Chrome/)) {
+        $("#ai-board-carousel").hide();
+        $("#safari-carousel").show();
+     }
 });

--- a/index.html
+++ b/index.html
@@ -31,6 +31,61 @@ js-package: home-ai
                     <h1 class="text-center">Ultra96</h1>
                 </div>
             </div>
+        <div id="safari-carousel" class="carousel slide" data-ride="carousel">
+            <!-- Indicators -->
+            <ol class="carousel-indicators">
+                <li data-target="#safari-carousel" data-slide-to="0" class="active"></li>
+                <li data-target="#safari-carousel" data-slide-to="1"></li>
+                <li data-target="#safari-carousel" data-slide-to="2"></li>
+                <li data-target="#safari-carousel" data-slide-to="3"></li>
+            </ol>
+            
+            <!-- Wrapper for slides -->
+            <div class="carousel-inner" role="listbox">
+                <div class="item active">
+                    <img class="lazyload img-responsive" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                    data-src="/assets/images/ultra-96-front-hd.png" id="1" data-url="/products/ultra96/" alt="Ultra96">
+                    <div class="carousel-caption">
+                        Ultra96
+                        <a class="btn view-more-info" href="/products/ultra96/">More Info</a>
+                    </div>
+                </div>
+                <div class="item">
+                    <img class="lazyload img-responsive" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                    data-src="/assets/images/sophon-edge-tpu-board.png" id="2" data-url="https://www.96boards.org/product/sophon-edge/" alt="Sophon Edge">
+                    <div class="carousel-caption">
+                        Sophon Edge
+                        <a class="btn view-more-info" href="https://www.96boards.org/product/sophon-edge/">More Info</a>
+                    </div>
+                </div>
+                <div class="item">
+                    <img class="lazyload img-responsive" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                    data-src="/assets/images/rock960_front-resized.png" id="3" data-url="/products/rock960/" alt="Rock960">
+                    <div class="carousel-caption">
+                        Rock960
+                        <a class="btn view-more-info" href="/products/rock960/">More Info</a>
+                    </div>
+                </div>
+                <div class="item">
+                    <img class="lazyload img-responsive" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                    data-src="/assets/images/hikey970-optimized.png" id="4" data-url="/products/hikey970/" alt="HiKey970">
+                    <div class="carousel-caption">
+                        HiKey970
+                        <a class="btn view-more-info" href="/products/hikey970/">More Info</a>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Controls -->
+            <a class="left carousel-control" href="#safari-carousel" role="button" data-slide="prev">
+                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+                <span class="sr-only">Previous</span>
+            </a>
+            <a class="right carousel-control" href="#safari-carousel" role="button" data-slide="next">
+                <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+                <span class="sr-only">Next</span>
+            </a>
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
Fixed the Homepage carousel on Safari. Carousel was not working correctly on Safari. I've detected whether the AppleWebKit is being used and hidden the carousel that doesn't work and displayed a standard Bootstrap 3 carousel.