### PR TITLE
Updating the landing page and adding a /boards/ page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,3 +30,4 @@ defaults:
 readme_index:
   enabled:          true
   remove_originals: true
+include: ['_pages']

--- a/_includes/ai_boards.html
+++ b/_includes/ai_boards.html
@@ -11,6 +11,9 @@
                         <a class="btn btn-primary" href="{{board.url}}">
                             View Board
                         </a>
+                        <a class="btn btn-secondary" href="/boards/">
+                            View All
+                        </a>
                     </div>
                 {% endfor %}
             </div>

--- a/_includes/ai_title_row.html
+++ b/_includes/ai_title_row.html
@@ -1,0 +1,5 @@
+<div class="row" id="ai_title_row">
+    <div class="container text-center">
+        <h1>Welcome to 96Boards <span class="ai_word"><span class="ai_logo"></span>I</span></h1>
+    </div>
+</div>

--- a/_includes/display_all_boards.html
+++ b/_includes/display_all_boards.html
@@ -1,0 +1,18 @@
+<div class="row" id="all_boards_row">
+    <div class="container">
+        <div class="row">
+        {% for board in site.data.boards.items %}
+            <div class="col-xs-12 col-sm-4 board_col">
+                <div class="board_image" style="background-image: url({{board.image}});"></div>
+                <h4>{{board.title}}</h4>
+                <p class="board_desc">
+                    {{board.description}}
+                </p>
+                <a class="btn btn-primary board_button" href="{{board.url}}">
+                    View Board
+                </a>
+            </div>
+        {% endfor %}
+        </div>
+    </div>
+</div>

--- a/_pages/boards.md
+++ b/_pages/boards.md
@@ -1,0 +1,10 @@
+---
+title: All AI 96Boards
+permalink: /boards/
+description: >
+    View the collection of AI-powered 96Boards.
+layout: flow
+flow:
+    - row: custom_include_row
+      source: display_all_boards.html
+---

--- a/assets/css/app/custom.scss
+++ b/assets/css/app/custom.scss
@@ -163,3 +163,68 @@ div#github_controls a.btn {
     position: absolute;
     background-repeat: no-repeat;
 }
+#all_boards_row .row {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display:         flex;
+  flex-wrap: wrap;
+}
+#all_boards_row .row > [class*='col-'] {
+  display: flex;
+  flex-direction: column;
+}
+@media(min-width:1000px){
+    p.board_desc {
+        height: 167px;
+    }
+}
+
+#all_boards_row h4 {
+    height: 50px;
+}
+span.ai_logo:before {
+    content: url();
+    display:inline;
+    background-size: contain;
+    background-image: url('/assets/images/96Boards-ai-logo-dark.png');
+    display: inline-block;
+    background-position:center center;
+    background-repeat:no-repeat;
+    width: 30px;
+    height: 27px;
+    content:"";
+}
+
+#ai_boards_row button {
+    height: 40px;
+    margin-top:10px;
+    background-color: black !important;
+    width: 40px;
+    border: 1px solid #eee;
+    font-size: 24px;
+}
+#ai_boards_row button:hover {
+    height: 40px;
+    margin-top:10px;
+    background-color: white !important;
+    width: 40px;
+    font-size: 24px;
+}
+
+@media (max-width: 1000px) {
+    #wrapper #flow_wrapper div#ai_title_row {
+        padding-top: 40px !important;
+    }
+}
+div#ai_title_row {
+    background-color: #000 !important;
+    color: white;
+}div#ai_title_row h1 {
+    color: white;
+}
+.owl-nav {
+    position: absolute;
+    top: -80px;
+    width: 100%;
+}

--- a/assets/js/app/home.js
+++ b/assets/js/app/home.js
@@ -4,11 +4,11 @@ $(document).ready(function(){
     ai_boards_carousel.owlCarousel({
     items: 4,
     loop: false,
-    dots: true,
-    nav: false,
+    dots: false,
+    nav: true,
     margin: 10,
     autoplay: true,
-    rewind: true,
+    rewind: false,
     autoplayTimeout: 3000,
     autoplayHoverPause: true,
     responsive: {
@@ -16,10 +16,10 @@ $(document).ready(function(){
         items: 1
         },
         600: {
-        items: 2
+        items: 1
         },
         1000: {
-        items: 3
+        items: 1
         }
     }
     });

--- a/index.md
+++ b/index.md
@@ -22,6 +22,8 @@ jumbotron:
                   url: https://www.linaro.org/news/horizon-robotics-joins-linaro-96boards-steering-committee/
 flow:
     - row: custom_include_row
+      source: ai_title_row.html
+    - row: custom_include_row
       source: ai_boards.html
 edit-on-github: true
 particles_js: true


### PR DESCRIPTION
Updating homepage and adding a /boards/ page
- added the /boards/ page
- Added carousel arrows instead of dots
- Added "Welcome to 96Boards AI" title
