### PR TITLE
Explicitly require the kramdown-parser-gfm gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gem "jumbo-jekyll-theme", "5.6.9.2"
 
 group :jekyll_plugins do
   gem "jekyll-data"
+  gem "kramdown-parser-gfm"
 end


### PR DESCRIPTION
Explicitly require the kramdown-parser-gfm gem